### PR TITLE
Inject connection directly rather than by name.

### DIFF
--- a/activerecord/test/cases/relation_test.rb
+++ b/activerecord/test/cases/relation_test.rb
@@ -44,14 +44,14 @@ module ActiveRecord
 
     def test_default_connection
       relation = Relation.new(Post, :b, nil)
-      assert_equal Post.connection, relation.connection
+      assert_same Post.connection, relation.send(:connection)
     end
 
     def test_injected_connection
-      relation = Relation.new(Post, :b, nil, {}, "ARUnit2Model")
+      relation = Relation.new(Post, :b, nil, {}, Post.connection_handler.retrieve_connection("ARUnit2Model"))
 
-      assert_not_equal Post.connection, relation.connection
-      assert_equal Post.retrieve_connection("ARUnit2Model"), relation.connection
+      assert_not_same Post.connection, relation.send(:connection)
+      assert_same Post.connection_handler.retrieve_connection("ARUnit2Model"), relation.send(:connection)
     end
 
     def test_extensions


### PR DESCRIPTION
The only reason for injecting the connection by name was to avoid issues
with marshalling. To me, it is not currently clear whether we actually
want to allow marshalling in this case. We could probably do something
like allow marshalling it if the connection was established from a
specification name, but for now we can just be conservative.
