### PR TITLE
Don't attempt to manipulate the class level connection

### DIFF
--- a/activerecord/lib/active_record/collection_cache_key.rb
+++ b/activerecord/lib/active_record/collection_cache_key.rb
@@ -29,7 +29,7 @@ module ActiveRecord
           arel = query.arel
         end
 
-        result = connection.select_one(arel, nil)
+        result = collection.connection.select_one(arel, nil)
 
         if result.blank?
           size = 0

--- a/activerecord/lib/active_record/connection_handling.rb
+++ b/activerecord/lib/active_record/connection_handling.rb
@@ -87,23 +87,7 @@ module ActiveRecord
     # also be used to "borrow" the connection to do database work unrelated
     # to any of the specific Active Records.
     def connection
-      @connection || retrieve_connection
-    end
-
-    def using_connection(connection) # :nodoc:
-      connection_monitor.synchronize do
-        begin
-          @connection ||= nil
-          previous_conn, @connection = @connection, connection
-          yield self
-        ensure
-          @connection = previous_conn
-        end
-      end
-    end
-
-    def connection_monitor # :nodoc:
-      @connection_monitor ||= Monitor.new
+      retrieve_connection
     end
 
     attr_writer :connection_specification_name

--- a/activerecord/lib/active_record/model_schema.rb
+++ b/activerecord/lib/active_record/model_schema.rb
@@ -305,13 +305,13 @@ module ActiveRecord
 
       # Determines if the primary key values should be selected from their
       # corresponding sequence before the insert statement.
-      def prefetch_primary_key?
+      def prefetch_primary_key?(connection = self.connection)
         connection.prefetch_primary_key?(table_name)
       end
 
       # Returns the next value that will be used as the primary key on
       # an insert statement.
-      def next_sequence_value
+      def next_sequence_value(connection = self.connection)
         connection.next_sequence_value(sequence_name)
       end
 

--- a/activerecord/lib/active_record/querying.rb
+++ b/activerecord/lib/active_record/querying.rb
@@ -37,7 +37,7 @@ module ActiveRecord
     #
     #   Post.find_by_sql ["SELECT title FROM posts WHERE author = ? AND created > ?", author_id, start_date]
     #   Post.find_by_sql ["SELECT body FROM comments WHERE author = :user_id OR approved_by = :user_id", { :user_id => user_id }]
-    def find_by_sql(sql, binds = [], preparable: nil, &block)
+    def find_by_sql(sql, binds = [], preparable: nil, connection: self.connection, &block)
       result_set = connection.select_all(sanitize_sql(sql), "#{name} Load", binds, preparable: preparable)
       column_types = result_set.column_types.dup
       columns_hash.each_key { |k| column_types.delete k }


### PR DESCRIPTION
There were several methods that `Relation` had overridden to set the
class level connection on its AR subclass before calling. The majority
of these methods are ones where we either control the implementation
(and don't expect it to be overridden)

The one case where we don't always control the implementation was
`prefetch_primary_key` and `next_sequence_value`. Interestingly, the
only consumer of those that I'm aware of (Oracle adapter) is using
`@connection` not the class method, so it wouldn't have picked up
changes from `use_connection` anyway.

I've intentionally left the schema related queries on the main
connection for now. We can assume that these methods will return the
same results regardless of the connection that it's run on, and I don't
think we're yet ready to answer the question of which connection these
will run on yet, and the answer to that question is going to depend on
which public APIs we end up introducing on top of that.